### PR TITLE
Fix upstart script to be correct redirect

### DIFF
--- a/templates/consul.conf.j2
+++ b/templates/consul.conf.j2
@@ -20,7 +20,7 @@ script
 
   # Set GOMAXPROCS to use all our CPUs, because Consul can block a scheduler thread
   # Use su to become consul user non-interactively on old Upstart versions (see http://superuser.com/a/234541/76168)
-  exec su -s /bin/sh -c 'GOMAXPROCS=`nproc` exec "$0" "$@" 1>> {{ consul_log_file }} &2>1' consul -- /opt/consul/bin/consul agent \
+  exec su -s /bin/sh -c 'GOMAXPROCS=`nproc` exec "$0" "$@" 1>> {{ consul_log_file }} 2>&1' consul -- /opt/consul/bin/consul agent \
 {% if consul_dynamic_bind %}
     -bind=$BIND \
 {% endif %}


### PR DESCRIPTION
PR clone for upstream PR: https://github.com/savagegus/ansible-consul/pull/204
Note: this also replaces https://github.com/vincepii/ansible-consul/pull/1 (which might not apply to current upstream master anymore )

---

this script fails to start.

```
$ sudo tail /var/log/upstart/consul.log
/opt/consul/bin/consul: 1: /opt/consul/bin/consul: cannot create 1: Permission denied
```