### PR TITLE
if consul_client_address set (in consul.conf), in the upstart script do not set -client flag …

### DIFF
--- a/templates/consul.conf.j2
+++ b/templates/consul.conf.j2
@@ -24,7 +24,7 @@ script
 {% if consul_dynamic_bind %}
     -bind=$BIND \
 {% endif %}
-{# In case 'consul_client_address' is set, will only configure it in consul.conf file, not here #}
+{# In case 'consul_client_address' is set, will only configure it in /etc/consul.conf, not here #}
 {% if consul_client_address_bind and not consul_client_address %}
     -client=$CLIENT_BIND \
 {% endif %}

--- a/templates/consul.conf.j2
+++ b/templates/consul.conf.j2
@@ -24,7 +24,8 @@ script
 {% if consul_dynamic_bind %}
     -bind=$BIND \
 {% endif %}
-{% if consul_client_address_bind %}
+{# In case 'consul_client_address' is set, will only configure it in consul.conf file, not here #}
+{% if consul_client_address_bind and not consul_client_address %}
     -client=$CLIENT_BIND \
 {% endif %}
     -config-dir={{ consul_config_dir }} \


### PR DESCRIPTION
… (from unconfigurable interface 'eth0')

clone PR of public upstream PR: https://github.com/savagegus/ansible-consul/pull/205